### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,10 @@ This project provides MCP tools for HPC. These are designed to integrate with LL
 is to integrate with LLMs called from IDEs such as [cursor](https://cursor.com/) and
 [vscode](https://code.visualstudio.com/).
 
+<a href="https://glama.ai/mcp/servers/@TomMelt/hpc-mcp">
+  <img width="380" height="200" src="https://glama.ai/mcp/servers/@TomMelt/hpc-mcp/badge" alt="HPC-MCP MCP server" />
+</a>
+
 ## Quick Start Guide :rocket:
 
 This project uses [uv](https://github.com/astral-sh/uv) for dependency management and installation.


### PR DESCRIPTION
This PR adds a badge for the [HPC-MCP](https://glama.ai/mcp/servers/@TomMelt/hpc-mcp) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/@TomMelt/hpc-mcp">
  <img width="380" height="200" src="https://glama.ai/mcp/servers/@TomMelt/hpc-mcp/badge" alt="HPC-MCP MCP server" />
</a>

Glama performs regular codebase and documentation checks to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly assess that the MCP server is safe, server capabilities, and instructions for installing the server.